### PR TITLE
core: fix memory leak in generate_and_parse_new_msg

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -1178,6 +1178,7 @@ static int generate_and_parse_new_msg(sip_msg* msg, sip_msg*& p_msg)
     *c++ = '\0';
 
     p_msg->buf = string(buf, request_len);
+	delete[] buf;
 
     // and parse it
     char* err_msg=0;


### PR DESCRIPTION
Hello,

This PR fixes a memory leak in generate_and_parse_new_msg by ensuring the temporary heap buffer used to build the generated SIP message is freed after its contents are copied into p_msg->buf. This prevents unbounded memory growth when generating/parsing messages repeatedly.