### PR TITLE
core: fix memory leak in trans_timer::fire

### DIFF
--- a/core/sip/sip_trans.cpp
+++ b/core/sip/sip_trans.cpp
@@ -205,7 +205,8 @@ void trans_timer::fire()
 		// 2. we have already set a new one
 		// -> anyway, don't fire the old one !!!
                 bucket->unlock();
-		return;
+		delete this;
+        return;
 	    }
 
 	    // timer_expired unlocks the bucket
@@ -220,6 +221,7 @@ void trans_timer::fire()
     else {
 	ERROR("Invalid bucket id\n");
     }
+    delete this;
 }
 
 /**


### PR DESCRIPTION
Hello,

This PR fixes a memory leak in trans_timer::fire.
The wheel-timer implementation **wheeltimer::process_current_timers()** only disarms fired timers (removes them from bucket lists) but does not delete the timer objects.