### PR TITLE
reg_agent: keep Expires: 0 on de-REGISTER with contact

### DIFF
--- a/core/AmSipRegistration.cpp
+++ b/core/AmSipRegistration.cpp
@@ -163,7 +163,7 @@ bool AmSIPRegistration::doUnregister()
   int flags=0;
   string hdrs = SIP_HDR_COLSP(SIP_HDR_EXPIRES) "0" CRLF;
   if(!info.contact.empty()) {
-    hdrs = SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
+    hdrs += SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
     hdrs += info.contact + ">" + CRLF;
     flags = SIP_FLAGS_NOCONTACT;
   }


### PR DESCRIPTION
doUnregister() overwrote the "Expires: 0" header with the Contact header instead of appending to it, so any de-registration for a subscriber with a contact set left the outgoing REGISTER without an Expires header at all. The registrar then treated it as a normal refresh instead of removing the binding, while SEMS locally deleted its registration record, leaving the two sides out of sync.