### PR TITLE
RegisterCache: fix missing climits include for LONG_MAX

### DIFF
--- a/apps/sbc/RegisterCache.h
+++ b/apps/sbc/RegisterCache.h
@@ -9,6 +9,7 @@
 #include "AmUriParser.h"
 #include "AmAppTimer.h"
 
+#include <climits>
 #include <string>
 #include <map>
 #include <unordered_map>


### PR DESCRIPTION
get_lowest_expire() uses LONG_MAX without including <climits>, which fails to build with newer/stricter compilers.