### PR TITLE
core: honor caller-provided headers in send_200_ack() and cancel()

### DIFF
--- a/core/AmSipDialog.cpp
+++ b/core/AmSipDialog.cpp
@@ -1064,6 +1064,9 @@ int AmSipDialog::send_200_ack(unsigned int inv_cseq,
   if(body != NULL)
     req.body = *body;
 
+  if (!hdrs.empty())
+    req.hdrs = hdrs;
+
   if(onTxRequest(req,flags) < 0)
     return -1;
 

--- a/core/AmSipDialog.cpp
+++ b/core/AmSipDialog.cpp
@@ -1000,7 +1000,8 @@ int AmSipDialog::cancel(const string &hdrs)
 	  if(getStatus() != Cancelling){
 	    setStatus(Cancelling);
 	    return SipCtrlInterface::cancel(&t->second.tt, local_tag,
-					    t->first, t->second.hdrs);
+					    t->first,
+					    hdrs.empty() ? t->second.hdrs : hdrs);
 	  }
 	  else {
 	    ILOG_DLG(L_ERR, "INVITE transaction has already been cancelled\n");


### PR DESCRIPTION
Hello,
Two places in AmSipDialog silently ignore the hdrs argument the application passes in:

send_200_ack() never copies the given headers into the ACK, so custom headers are dropped when ACKing a 2xx.
cancel() always re-sends the headers stored in the INVITE transaction instead of the caller's headers.
This patch copies the headers in send_200_ack(), and in cancel() uses the caller's headers when non-empty, falling back to the stored ones otherwise. No behavior change when no headers are passed.