### PR TITLE
xmlrpc2di: actually register builtin XML-RPC methods

### DIFF
--- a/apps/sbc/RegisterCache.h
+++ b/apps/sbc/RegisterCache.h
@@ -9,6 +9,7 @@
 #include "AmUriParser.h"
 #include "AmAppTimer.h"
 
+#include <climits>
 #include <string>
 #include <map>
 #include <unordered_map>

--- a/core/AmSipRegistration.cpp
+++ b/core/AmSipRegistration.cpp
@@ -163,7 +163,7 @@ bool AmSIPRegistration::doUnregister()
   int flags=0;
   string hdrs = SIP_HDR_COLSP(SIP_HDR_EXPIRES) "0" CRLF;
   if(!info.contact.empty()) {
-    hdrs = SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
+    hdrs += SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
     hdrs += info.contact + ">" + CRLF;
     flags = SIP_FLAGS_NOCONTACT;
   }


### PR DESCRIPTION
Hello,
The constructor printed "enabled builtin method ..." for calls, get_cpsavg, get_cpsmax, get_callsavg, get_callsmax, get_cpslimit, set_cpslimit and loglevel/shutdownmode methods, but never called s->addMethod() for them, so all builtin methods returned "unknown method name". Register them (and the "di" method when export_di=yes) after the server object is created.