### PR TITLE
core: detect dlopen() failure and tolerate undefined log facility symbol

### DIFF
--- a/apps/sbc/RegisterCache.h
+++ b/apps/sbc/RegisterCache.h
@@ -9,6 +9,7 @@
 #include "AmUriParser.h"
 #include "AmAppTimer.h"
 
+#include <climits>
 #include <string>
 #include <map>
 #include <unordered_map>

--- a/core/AmPlugIn.cpp
+++ b/core/AmPlugIn.cpp
@@ -50,6 +50,13 @@
 using std::set;
 using std::make_shared;
 
+/** Weak stub so plugins that accidentally reference this symbol (e.g. via shared
+ *  headers) still load. Plugins that provide a log facility (e.g. di_log) define
+ *  it strongly and override this. */
+__attribute__((weak)) extern "C" void* log_facility_factory_create(void) {
+  return nullptr;
+}
+
 static unsigned int pcm16_bytes2samples(long h_codec, unsigned int num_bytes)
 {
   return num_bytes / 2;
@@ -296,12 +303,12 @@ int AmPlugIn::loadPlugIn(const string& file, const string& plugin_name,
   }
   free(pname);
 
-  auto h_dl = make_shared<dlhandle>(dlopen(file.c_str(), dlopen_flags));
-
-  if(!h_dl){
-    ERROR("AmPlugIn::loadPlugIn: %s: %s\n",file.c_str(),dlerror());
+  void* raw_handle = dlopen(file.c_str(), dlopen_flags);
+  if (!raw_handle) {
+    ERROR("AmPlugIn::loadPlugIn: %s: %s\n", file.c_str(), dlerror());
     return -1;
   }
+  auto h_dl = make_shared<dlhandle>(raw_handle);
 
   FactoryCreate fc = NULL;
   amci_exports_t* exports = (amci_exports_t*)dlsym(*h_dl, "amci_exports");

--- a/core/AmSipRegistration.cpp
+++ b/core/AmSipRegistration.cpp
@@ -163,7 +163,7 @@ bool AmSIPRegistration::doUnregister()
   int flags=0;
   string hdrs = SIP_HDR_COLSP(SIP_HDR_EXPIRES) "0" CRLF;
   if(!info.contact.empty()) {
-    hdrs = SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
+    hdrs += SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
     hdrs += info.contact + ">" + CRLF;
     flags = SIP_FLAGS_NOCONTACT;
   }


### PR DESCRIPTION
Hi,
AmPlugIn::loadPlugIn() wrapped the dlopen() result directly into a shared_ptr<dlhandle> and tested the shared pointer for null, which never holds even when dlopen() failed: the failure went unnoticed and loading continued with a NULL handle. Check the raw dlopen() handle and report dlerror() before wrapping it.

Also provide a weak default definition of log_facility_factory_create() (the export name declared in AmApi.h) so modules that reference this symbol resolve it against the core instead of failing to load; modules providing their own log facility define it strongly and override the stub.